### PR TITLE
Update cookie authorization guide link in README_EN

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Telegram-бот для администрирования Remnawave: управ�
 ### Что нового
 - Ускорение отклика: уменьшен `poll_interval` до 0.5s.
 
-Справка по eGames: [`wiki.egam.es`](https://wiki.egam.es/)
+Wiki по скрипту eGames'а: [`wiki.egam.es`](https://wiki.egam.es/)
 
 ### Авторизация через cookie (eGames)
 1) Получите cookie в панели Remnawave согласно инструкции https://wiki.egam.es/ru/configuration/external-api/#%D0%BF%D0%BE%D0%BB%D1%83%D1%87%D0%B5%D0%BD%D0%B8%D0%B5-%D0%B4%D0%BE%D1%81%D1%82%D1%83%D0%BF%D0%B0-%D0%BA-api-%D1%81-%D0%B8%D1%81%D0%BF%D0%BE%D0%BB%D1%8C%D0%B7%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5%D0%BC-cookie.

--- a/README_EN.md
+++ b/README_EN.md
@@ -28,7 +28,7 @@ Contact points:
 Reference for eGames: [`wiki.egam.es`](https://wiki.egam.es/)
 
 ### Cookie-based Authorisation (eGames)
-1. Obtain cookies from the Remnawave panel using the guide: https://wiki.egam.es/ru/configuration/external-api/#%D0%BF%D0%BE%D0%BB%D1%83%D1%87%D0%B5%D0%BD%D0%B8%D0%B5-%D0%B4%D0%BE%D1%81%D1%82%D1%83%D0%BF%D0%B0-%D0%BA-api-%D1%81-%D0%B8%D1%81%D0%BF%D0%BE%D0%BB%D1%8C%D0%B7%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5%D0%BC-cookie.
+1. Obtain cookies from the Remnawave panel using the guide: https://wiki.egam.es/configuration/external-api/#accessing-api-through-cookies.
 2. Store them in "NAME=VALUE" JSON and set the string in `REMNAWAVE_COOKIES` (example: `{NAME:VALUE}`).
 3. Optionally use the fallback `COOKIES` variable.
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -25,7 +25,7 @@ Contact points:
 ### What’s New
 - Faster polling: `poll_interval` reduced to 0.5s.
 
-Reference for eGames: [`wiki.egam.es`](https://wiki.egam.es/)
+eGames's script related Wiki: [`wiki.egam.es`](https://wiki.egam.es/)
 
 ### Cookie-based Authorisation (eGames)
 1. Obtain cookies from the Remnawave panel using the guide: https://wiki.egam.es/configuration/external-api/#accessing-api-through-cookies.


### PR DESCRIPTION
This pull request makes small documentation improvements to both the Russian and English README files by clarifying the references to the eGames wiki and updating a link for cookie-based authorization.

- The Russian README now refers to the wiki as the "Wiki по скрипту eGames'а" for clarity.
- The English README updates the wiki reference to "eGames's script related Wiki" and corrects the link for cookie-based authorization to point to the English documentation.